### PR TITLE
✨ [feature]#37 JWT 토큰 캐싱 및 재발급 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,9 @@ dependencies {
 
     //.env
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+
+    //redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 
 dependencyManagement {

--- a/src/main/java/profect/group1/goormdotcom/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/profect/group1/goormdotcom/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "AUTH409", "이미 존재하는 이메일입니다"),
     AUTH_NOT_EXISTS(HttpStatus.NOT_FOUND, "AUTH404", "존재하지 않는 사용자입니다"),
     INSUFFICIENT_ROLE(HttpStatus.FORBIDDEN, "AUTH403", "요청에 필요한 권한이 없습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401", "유효하지 않은 토큰입니다."),
 
     COMMON_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "존재하지 않는 공통 코드입니다"),
     COMMON_CODE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMON409", "이미 존재하는 공통 코드입니다"),

--- a/src/main/java/profect/group1/goormdotcom/common/config/RedisConfig.java
+++ b/src/main/java/profect/group1/goormdotcom/common/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package profect.group1.goormdotcom.common.config;
+
+import io.lettuce.core.ClientOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password:}")
+    private String redisPassword;
+
+    @Value("${spring.data.redis.database:0}")
+    private int redisDatabase;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .clientOptions(ClientOptions.builder()
+                        .disconnectedBehavior(ClientOptions.DisconnectedBehavior.REJECT_COMMANDS)
+                        .build())
+                .commandTimeout(Duration.ofSeconds(2))
+                .build();
+
+        RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration();
+        serverConfig.setHostName(redisHost);
+        serverConfig.setPort(redisPort);
+        serverConfig.setDatabase(redisDatabase);
+
+        if (redisPassword != null && !redisPassword.isBlank()) {
+            serverConfig.setPassword(redisPassword);
+        }
+
+        return new LettuceConnectionFactory(serverConfig, clientConfig);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
+    }
+}

--- a/src/main/java/profect/group1/goormdotcom/common/config/SecurityConfig.java
+++ b/src/main/java/profect/group1/goormdotcom/common/config/SecurityConfig.java
@@ -98,7 +98,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/public/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers("/api/v1/users/register", "/api/v1/users/login").permitAll()
+                        .requestMatchers("/api/v1/users/register", "/api/v1/users/login", "/api/v1/users/refresh").permitAll()
                         // 스웨거 허용
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/profect/group1/goormdotcom/common/security/JwtTokenProvider.java
+++ b/src/main/java/profect/group1/goormdotcom/common/security/JwtTokenProvider.java
@@ -1,63 +1,175 @@
 package profect.group1.goormdotcom.common.security;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtParser;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 import java.util.UUID;
 
-import profect.group1.goormdotcom.user.domain.enums.UserRole;
-
-// JWT 토큰 생성/파싱: secret.yml에 만료기간 미설정 시 만료되지않음
 @Component
 public class JwtTokenProvider {
 
-    private final PrivateKey privateKey;
-    private final long accessTokenValidityMs;
+    // ==================== 설정 값 ====================
 
-    public JwtTokenProvider(
-            @Value("${spring.jwt.private-key}") String privateKeyPem,
-            @Value("${spring.jwt.accessTokenValidityMs:-1}") long accessTokenValidityMs
-    ) {
-        this.privateKey = parsePrivateKey(privateKeyPem);
-        this.accessTokenValidityMs = accessTokenValidityMs;
-    }
+    /**
+     * PKCS#8 형식의 RSA Private Key PEM
+     * -----BEGIN PRIVATE KEY-----
+     * ...
+     * -----END PRIVATE KEY-----
+     */
+    @Value("${spring.jwt.private-key}")
+    private String privateKeyPem;
 
-    private PrivateKey parsePrivateKey(String base64) {
+    @Value("${spring.jwt.issuer}")
+    private String issuer;
+
+    @Value("${spring.jwt.audience}")
+    private String audience;
+
+    @Value("${spring.jwt.access-expiration-ms}")
+    private long accessTokenExpirationMs;
+
+    @Value("${spring.jwt.refresh-expiration-ms}")
+    private long refreshTokenExpirationMs;
+
+    // ==================== 내부 필드 ====================
+
+    private RSAPrivateKey privateKey;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // ==================== 초기화 ====================
+
+    @PostConstruct
+    public void init() {
         try {
-            byte[] der = Base64.getDecoder().decode(base64.trim());
-            return KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(der));
+            this.privateKey = loadPrivateKey(privateKeyPem);
         } catch (Exception e) {
-            throw new IllegalStateException("Invalid RSA private key", e);
+            throw new IllegalStateException("Failed to load RSA private key", e);
         }
     }
 
-    public String generateAccessToken(UUID userId, String roleCode) {
+    private RSAPrivateKey loadPrivateKey(String pem) throws Exception {
+        String clean = pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] decoded = Base64.getDecoder().decode(clean);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PrivateKey key = keyFactory.generatePrivate(keySpec);
+        return (RSAPrivateKey) key;
+    }
+
+    // ==================== 토큰 생성 ====================
+
+    public String generateAccessToken(UUID userId, String role, String jti) {
         Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpirationMs);
 
-        UserRole role = UserRole.fromCode(roleCode);
-        System.out.println("role::: " + role.name());
-
-        var builder =Jwts.builder()
-                .header().add("kid", "key-2025-11-06-01").and()
+        return Jwts.builder()
                 .subject(userId.toString())
-                .claim("role", role.name())
+                .claim("role", role)
+                .claim("iss", issuer)      // issuer
+                .claim("aud", audience)    // audience
+                .id(jti)
                 .issuedAt(now)
-                .issuer("https://public.goorm.store")
-                .audience().add("goormdotcom-aud").and()
-                .signWith(privateKey, Jwts.SIG.RS256);
+                .expiration(expiry)
+                .signWith(privateKey, Jwts.SIG.RS256)   // RSA private key로 서명
+                .compact();
+    }
 
-        if (accessTokenValidityMs > 0) {
-            Date exp = new Date(now.getTime() + accessTokenValidityMs);
-            builder.expiration(exp);
+    public String generateRefreshToken(UUID userId, String role, String jti) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpirationMs);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("role", role)
+                .claim("iss", issuer)
+                .claim("aud", audience)
+                .id(jti)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(privateKey, Jwts.SIG.RS256)
+                .compact();
+    }
+
+    // ==================== 토큰 파싱 ====================
+
+    /** "Bearer " 프리픽스 제거 */
+    private String stripBearer(String token) {
+        if (token == null) {
+            throw new IllegalArgumentException("Token is null");
         }
+        if (token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return token;
+    }
 
-        return builder.compact();
+    /**
+     * 서명 검증 없이 payload만 파싱하는 메서드
+     * - RS256, HS256 등 어떤 alg라도 상관 없이 payload 부분만 Base64URL 디코딩
+     */
+    public Claims parseClaimsWithoutVerify(String token) {
+        try {
+            String compact = stripBearer(token);
+            String[] parts = compact.split("\\.");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid JWT format");
+            }
 
+            // payload (두 번째 파트) Base64URL 디코딩
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+            String payloadJson = new String(payloadBytes, StandardCharsets.UTF_8);
+
+            // JSON -> Map -> Claims
+            Map<String, Object> map = objectMapper.readValue(
+                    payloadJson,
+                    new TypeReference<Map<String, Object>>() {}
+            );
+
+            // JJWT의 Claims로 변환 (sub, jti, iss, aud 등도 그대로 들어감)
+            return Jwts.claims(map);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot parse JWT", e);
+        }
+    }
+
+    public long getAccessTokenExpirationSeconds() {
+        return accessTokenExpirationMs / 1000;
+    }
+
+    public long getRefreshTokenExpirationSeconds() {
+        return refreshTokenExpirationMs / 1000;
+    }
+
+    public UUID getUserId(String token) {
+        Claims claims = parseClaimsWithoutVerify(token);
+        return UUID.fromString(claims.getSubject()); // sub
+    }
+
+    public String getRole(String token) {
+        Claims claims = parseClaimsWithoutVerify(token);
+        return claims.get("role", String.class);
+    }
+
+    public String getJti(String token) {
+        Claims claims = parseClaimsWithoutVerify(token);
+        return claims.getId(); // jti
     }
 }

--- a/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/UserController.java
+++ b/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/UserController.java
@@ -2,12 +2,10 @@ package profect.group1.goormdotcom.user.controller.external.v1;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import profect.group1.goormdotcom.user.controller.external.v1.dto.request.*;
 import profect.group1.goormdotcom.user.service.UserService;
-import profect.group1.goormdotcom.user.controller.external.v1.dto.request.RegisterRequestDto;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.response.MeResponseDto;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.response.RegisterResponseDto;
-import profect.group1.goormdotcom.user.controller.external.v1.dto.request.EditRequestDto;
-import profect.group1.goormdotcom.user.controller.external.v1.dto.request.LoginRequestDto;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.response.LoginResponseDto;
 import profect.group1.goormdotcom.user.service.dto.CreateUserDto;
 import profect.group1.goormdotcom.user.domain.User;
@@ -27,8 +25,8 @@ import lombok.AccessLevel;
 import profect.group1.goormdotcom.user.controller.auth.LoginUser;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.response.UserAddressListResponseDto;
 import profect.group1.goormdotcom.user.domain.UserAddress;
-import profect.group1.goormdotcom.user.controller.external.v1.dto.request.UserAddressRequestDto;
 import profect.group1.goormdotcom.user.service.UserAddressService;
+import profect.group1.goormdotcom.user.service.dto.LoginTokensDto;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -70,21 +68,14 @@ public class UserController implements UserApiDocs {
 
     @PostMapping("/login")
     public ApiResponse<LoginResponseDto> login(@RequestBody LoginRequestDto body) {
-        try {
-            String token = service.login(body.getEmail(), body.getPassword());
-            return ApiResponse.onSuccess(LoginResponseDto.of(token));
-        } catch (Exception e) {
-            String code = ErrorStatus._INTERNAL_SERVER_ERROR.getCode();
-            String message = ErrorStatus._INTERNAL_SERVER_ERROR.getMessage();
+        LoginTokensDto tokens = service.login(body.getEmail(), body.getPassword());
+        return ApiResponse.onSuccess(LoginResponseDto.of(tokens.getAccessToken(), tokens.getRefreshToken()));
+    }
 
-            switch (e.getMessage()) {
-                case "Invalid credentials":
-                    code = ErrorStatus.AUTH_NOT_EXISTS.getCode();
-                    message = ErrorStatus.AUTH_NOT_EXISTS.getMessage();
-                    break;
-            }
-            return ApiResponse.onFailure(String.valueOf(code), message, null);
-        }
+    @PostMapping("/refresh")
+    public ApiResponse<LoginResponseDto> refresh(@RequestBody RefreshTokenRequestDto body) {
+        LoginTokensDto tokens = service.refresh(body.getRefreshToken());
+        return ApiResponse.onSuccess(LoginResponseDto.of(tokens.getAccessToken(), tokens.getRefreshToken()));
     }
 
     @PostMapping("/leave")

--- a/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,8 @@
+package profect.group1.goormdotcom.user.controller.external.v1.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/dto/response/LoginResponseDto.java
+++ b/src/main/java/profect/group1/goormdotcom/user/controller/external/v1/dto/response/LoginResponseDto.java
@@ -11,7 +11,13 @@ public class LoginResponseDto {
     @Schema(description = "액세스 토큰 (JWT)")
     @NotBlank
     private String accessToken;
-    public static LoginResponseDto of(String token) { return new LoginResponseDto(token); }
+
+    @Schema(description = "리프레시 토큰")
+    @NotBlank
+    private String refreshToken;
+    public static LoginResponseDto of(String accessToken, String refreshToken) {
+        return new LoginResponseDto(accessToken, refreshToken);
+    }
 }
 
 

--- a/src/main/java/profect/group1/goormdotcom/user/service/UserService.java
+++ b/src/main/java/profect/group1/goormdotcom/user/service/UserService.java
@@ -1,39 +1,50 @@
 package profect.group1.goormdotcom.user.service;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import profect.group1.goormdotcom.apiPayload.ApiResponse;
 import profect.group1.goormdotcom.common.security.JwtTokenProvider;
 import profect.group1.goormdotcom.user.domain.User;
-import profect.group1.goormdotcom.user.service.dto.CreateUserDto;
-
-import org.springframework.stereotype.Service;
-import java.time.LocalDateTime;
-
-import org.springframework.transaction.annotation.Transactional;
-import lombok.RequiredArgsConstructor;
+import profect.group1.goormdotcom.user.domain.enums.UserRole;
+import profect.group1.goormdotcom.user.domain.mapper.UserMapper;
 import profect.group1.goormdotcom.user.infrastructure.client.CartClient;
-import java.util.UUID;
-import profect.group1.goormdotcom.apiPayload.ApiResponse;
 import profect.group1.goormdotcom.user.repository.UserRepository;
 import profect.group1.goormdotcom.user.repository.entity.UserEntity;
-import profect.group1.goormdotcom.user.domain.mapper.UserMapper;
-import profect.group1.goormdotcom.user.domain.enums.UserRole;
+import profect.group1.goormdotcom.user.service.dto.CreateUserDto;
+import profect.group1.goormdotcom.user.service.dto.LoginTokensDto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
+
     private final UserRepository repo;
     private final PasswordService passwordService;
     private final JwtTokenProvider jwtTokenProvider;
     private final CartClient cartClient;
     private final UserMapper userMapper;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String ACCESS_PREFIX = "access:";
+    private static final String REFRESH_PREFIX = "refresh:";
 
     public User findById(UUID id) {
-        UserEntity entity = repo.findById(id).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        UserEntity entity = repo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
         return this.userMapper.toDomain(entity);
     }
 
     public boolean isEmailExists(String email) {
-        boolean exists = repo.findByEmail(email).isPresent();
-        return exists;
+        return repo.findByEmail(email).isPresent();
     }
 
     @Transactional
@@ -64,16 +75,118 @@ public class UserService {
         return this.userMapper.toDomain(entity);
     }
 
-    public String login(String email, String password) {
-        UserEntity entity = repo.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
-        
+    @Transactional
+    public LoginTokensDto login(String email, String password) {
+        UserEntity entity = repo.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+
         String encoded = entity.getPassword();
         if (!passwordService.isMatch(password, encoded)) throw new IllegalArgumentException("Invalid credentials");
 
         entity.setLastLoginAt(LocalDateTime.now());
         repo.save(entity);
         String role = entity.getRole();
-        return jwtTokenProvider.generateAccessToken(entity.getId(), role);
+        UUID userId = entity.getId();
+
+        String accessJti = UUID.randomUUID().toString();
+        String refreshJti = UUID.randomUUID().toString();
+
+        String accessToken = jwtTokenProvider.generateAccessToken(userId, role, accessJti);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId, role, refreshJti);
+
+        long accessTtl = jwtTokenProvider.getAccessTokenExpirationSeconds();
+        long refreshTtl = jwtTokenProvider.getRefreshTokenExpirationSeconds();
+
+        String value = userId + ":" + role;
+
+        // Redis 장애 시 저장X, Token만 반환
+        try {
+            redisTemplate.opsForValue().set(
+                    ACCESS_PREFIX + accessJti,
+                    value,
+                    accessTtl,
+                    TimeUnit.SECONDS
+            );
+            redisTemplate.opsForValue().set(
+                    REFRESH_PREFIX + refreshJti,
+                    value,
+                    refreshTtl,
+                    TimeUnit.SECONDS
+            );
+        } catch (Exception e) {
+            log.error("Failed to save tokens to Redis on login. userId={}, email={}", userId, email, e);
+        }
+
+        return new LoginTokensDto(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public LoginTokensDto refresh(String refreshToken) {
+        // 1) JWT 구조 검증 + 정보 추출
+        UUID userId = jwtTokenProvider.getUserId(refreshToken);
+        String role = jwtTokenProvider.getRole(refreshToken);
+        String refreshJti = jwtTokenProvider.getJti(refreshToken);
+
+        String key = REFRESH_PREFIX + refreshJti;
+
+        // 2) Redis에서 refresh 유효성 확인
+        String value = null;
+        boolean redisError = false;
+        try {
+            value = redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            redisError = true;
+            log.error("Failed to read refresh token from Redis. Proceeding without Redis validation. key={}, userId={}", key, userId, e);
+        }
+
+        if (!redisError && value == null) {
+            throw new IllegalArgumentException("Invalid refresh token");
+        }
+
+        // 3) 토큰 회전: 기존 refresh 삭제 (Redis 정상일 때만)
+        if (!redisError) {
+            try {
+                redisTemplate.delete(key);
+            } catch (Exception e) {
+                log.error("Failed to delete old refresh token from Redis. key={}, userId={}", key, userId, e);
+            }
+        }
+
+        // 4) 새 jti 생성 + 토큰 재발급
+        String newAccessJti = UUID.randomUUID().toString();
+        String newRefreshJti = UUID.randomUUID().toString();
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(userId, role, newAccessJti);
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId, role, newRefreshJti);
+
+        long accessTtl = jwtTokenProvider.getAccessTokenExpirationSeconds();
+        long refreshTtl = jwtTokenProvider.getRefreshTokenExpirationSeconds();
+
+        String newValue = userId + ":" + role;
+
+        // 5) Redis에 새 토큰 저장 (Redis 정상일 때만)
+        if (!redisError) {
+            try {
+                redisTemplate.opsForValue().set(
+                        ACCESS_PREFIX + newAccessJti,
+                        newValue,
+                        accessTtl,
+                        TimeUnit.SECONDS
+                );
+                redisTemplate.opsForValue().set(
+                        REFRESH_PREFIX + newRefreshJti,
+                        newValue,
+                        refreshTtl,
+                        TimeUnit.SECONDS
+                );
+            } catch (Exception e) {
+                log.error("Failed to save rotated tokens to Redis. userId={}", userId, e);
+            }
+        } else {
+            log.warn("Refresh token rotated without Redis persistence. userId={}", userId);
+        }
+
+        return new LoginTokensDto(newAccessToken, newRefreshToken);
     }
 
     public void edit(UUID userId, String name, String email) {

--- a/src/main/java/profect/group1/goormdotcom/user/service/dto/LoginTokensDto.java
+++ b/src/main/java/profect/group1/goormdotcom/user/service/dto/LoginTokensDto.java
@@ -1,0 +1,11 @@
+package profect.group1.goormdotcom.user.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginTokensDto {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,17 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+      database: ${REDIS_DATABASE}
+      timeout: 5s
+      connect-timeout: 5s
+      repositories:
+        enabled: false
+
   cloud:
     openfeign:
       client:
@@ -18,7 +29,11 @@ spring:
             connectTimeout: 5000
             readTimeout: 5000
   jwt:
+    issuer: ${JWT_ISSUER}
+    audience: ${JWT_AUDIENCE}
     private-key: ${JWT_SECRET}
+    access-expiration-ms: ${JWT_ACCESS_EXPIRATION}        # 30분
+    refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION}
 
 management:
   endpoints:

--- a/src/test/java/profect/group1/goormdotcom/GoormdotcomApplicationTests.java
+++ b/src/test/java/profect/group1/goormdotcom/GoormdotcomApplicationTests.java
@@ -1,10 +1,14 @@
 package profect.group1.goormdotcom;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import profect.group1.goormdotcom.common.security.JwtTokenProvider;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -12,8 +16,14 @@ class GoormdotcomApplicationTests {
     @MockitoBean
     JwtTokenProvider jwtTokenProvider;
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private Environment environment;
+
+    @Test
+    void contextLoads() {
+        System.out.println("==== ACTIVE PROFILES ====");
+        System.out.println(Arrays.toString(environment.getActiveProfiles()));
+        System.out.println("==========================");
+    }
 
 }

--- a/src/test/java/profect/group1/goormdotcom/GoormdotcomApplicationTests.java
+++ b/src/test/java/profect/group1/goormdotcom/GoormdotcomApplicationTests.java
@@ -3,10 +3,14 @@ package profect.group1.goormdotcom;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import profect.group1.goormdotcom.common.security.JwtTokenProvider;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class GoormdotcomApplicationTests {
+    @MockitoBean
+    JwtTokenProvider jwtTokenProvider;
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/profect/group1/goormdotcom/user/UserControllerTest.java
+++ b/src/test/java/profect/group1/goormdotcom/user/UserControllerTest.java
@@ -1,4 +1,4 @@
-package profect.group1.goormdotcom.user.controller.external.v1;
+package profect.group1.goormdotcom.user;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import profect.group1.goormdotcom.apiPayload.ApiResponse;
 import profect.group1.goormdotcom.apiPayload.code.status.ErrorStatus;
 import profect.group1.goormdotcom.user.controller.auth.LoginUser;
+import profect.group1.goormdotcom.user.controller.external.v1.UserController;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.request.EditRequestDto;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.request.LoginRequestDto;
 import profect.group1.goormdotcom.user.controller.external.v1.dto.request.RegisterRequestDto;
@@ -23,12 +24,14 @@ import profect.group1.goormdotcom.user.domain.UserAddress;
 import profect.group1.goormdotcom.user.service.UserAddressService;
 import profect.group1.goormdotcom.user.service.UserService;
 import profect.group1.goormdotcom.user.service.dto.CreateUserDto;
+import profect.group1.goormdotcom.user.service.dto.LoginTokensDto;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -139,34 +142,32 @@ class UserControllerTest {
     @DisplayName("로그인 성공 시 반환된 액세스 토큰이 서비스에서 받은 토큰과 같다")
     void login_success() {
         // given
-        String token = "jwt-token";
+        LoginTokensDto loginTokens = new LoginTokensDto("jwt-access-token", "jwt-refresh-token");
         when(userService.login(loginRequestDto.getEmail(), loginRequestDto.getPassword()))
-                .thenReturn(token);
+                .thenReturn(loginTokens);
 
         // when
         ApiResponse<LoginResponseDto> response = userController.login(loginRequestDto);
 
         // then
         assertThat(response.getResult().getAccessToken())
-                .isEqualTo(token);
+                .isEqualTo(loginTokens.getAccessToken());
 
         verify(userService, times(1))
                 .login(loginRequestDto.getEmail(), loginRequestDto.getPassword());
     }
 
     @Test
-    @DisplayName("로그인 - 잘못된 자격 증명 시 AUTH_NOT_EXISTS 코드 반환")
+    @DisplayName("로그인 - 잘못된 자격 증명 시 예외 발생")
     void login_fail_invalidCredentials() {
         // given
         when(userService.login(loginRequestDto.getEmail(), loginRequestDto.getPassword()))
-                .thenThrow(new RuntimeException("Invalid credentials"));
+                .thenThrow(new IllegalArgumentException("Invalid credentials"));
 
-        // when
-        ApiResponse<LoginResponseDto> response = userController.login(loginRequestDto);
-
-        // then
-        assertThat(response.getCode())
-                .isEqualTo(ErrorStatus.AUTH_NOT_EXISTS.getCode());
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            userController.login(loginRequestDto);
+        });
 
         verify(userService, times(1))
                 .login(loginRequestDto.getEmail(), loginRequestDto.getPassword());

--- a/src/test/java/profect/group1/goormdotcom/user/service/UserServiceTest.java
+++ b/src/test/java/profect/group1/goormdotcom/user/service/UserServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import profect.group1.goormdotcom.apiPayload.ApiResponse;
 import profect.group1.goormdotcom.common.security.JwtTokenProvider;
 import profect.group1.goormdotcom.user.domain.User;
@@ -16,6 +18,7 @@ import profect.group1.goormdotcom.user.infrastructure.client.CartClient;
 import profect.group1.goormdotcom.user.repository.UserRepository;
 import profect.group1.goormdotcom.user.repository.entity.UserEntity;
 import profect.group1.goormdotcom.user.service.dto.CreateUserDto;
+import profect.group1.goormdotcom.user.service.dto.LoginTokensDto;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -23,9 +26,14 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -48,6 +56,12 @@ class UserServiceTest {
     @Mock
     private UserMapper userMapper;
 
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
     private CreateUserDto createUserDto;
     private UserEntity userEntity;
     private User user;
@@ -61,6 +75,7 @@ class UserServiceTest {
                 .email("test@example.com")
                 .password("encryptedPassword")
                 .name("testuser")
+                .role(UserRole.CUSTOMER.getCode())
                 .build();
 
         user = User.builder()
@@ -122,15 +137,24 @@ class UserServiceTest {
 
         when(passwordService.isMatch("Password123!", "encryptedPassword"))
                 .thenReturn(true);
+        
+        when(userRepository.save(any(UserEntity.class))).thenReturn(userEntity);
 
-        when(jwtTokenProvider.generateAccessToken(any(UUID.class), isNull()))
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        doNothing().when(valueOperations).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+
+        when(jwtTokenProvider.generateAccessToken(any(UUID.class), any(String.class), any(String.class)))
                 .thenReturn("accessToken");
+        when(jwtTokenProvider.generateRefreshToken(any(UUID.class), any(String.class), any(String.class)))
+                .thenReturn("refreshToken");
+        when(jwtTokenProvider.getAccessTokenExpirationSeconds()).thenReturn(3600L);
+        when(jwtTokenProvider.getRefreshTokenExpirationSeconds()).thenReturn(86400L);
 
         // when
-        String token = userService.login("test@example.com", "Password123!");
+        LoginTokensDto tokens = userService.login("test@example.com", "Password123!");
 
         // then
-        assertThat(token).isEqualTo("accessToken");
+        assertThat(tokens.getAccessToken()).isEqualTo("accessToken");
     }
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,6 +8,17 @@ spring:
     username: sa
     password:
 
+  data:
+    redis:
+      host: localhost
+      port: 6537
+      password: 1234
+      database: 0
+      timeout: 5s
+      connect-timeout: 5s
+      repositories:
+        enabled: false
+
   jwt:
     private-key: testJwt
     issuer: testIssuer

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: test
   datasource:
     url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,7 +7,10 @@ spring:
 
   jwt:
     private-key: ${JWT_SECRET}
-
+    issuer: testIssuer
+    audience: testAud
+    access-expiration-ms: 3600000
+    refresh-expiration-ms: 86400000
   jpa:
     hibernate:
       ddl-auto: create-drop   # 테스트할 때마다 스키마 새로 만들고 끝나면 드롭

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     password:
 
   jwt:
-    private-key: ${JWT_SECRET}
+    private-key: testJwt
     issuer: testIssuer
     audience: testAud
     access-expiration-ms: 3600000


### PR DESCRIPTION
## #️⃣ Issue Number
close #37 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
로그인 시 발급되는 accessToken / refreshToken에 대해 Redis에 상태를 저장하고,  
refresh 재발급 요청 시 Redis + JWT 정보를 함께 검증
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 📝 리뷰 요청사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 💻 테스트 결과

- <!--- 테스트 결과를 텍스트 or 캡쳐 형식으로 작성해주세요. -->
